### PR TITLE
Adding ability to provide a 'size' attribute on the modal cmp.

### DIFF
--- a/aura/strike_modal/strike_modal.cmp
+++ b/aura/strike_modal/strike_modal.cmp
@@ -4,6 +4,7 @@
     <aura:attribute name="primaryButtonLabel" type="String" default="Ok"/>
     <aura:attribute name="secondaryButtonLabel" type="String" default="Cancel"/>
     <aura:attribute name="variant" type="String"/>
+    <aura:attribute name="size" type="String"/>
 
     <aura:attribute name="showHeader" type="Boolean" default="{!true}"/>
     <aura:attribute name="showFooter" type="Boolean" default="{!true}"/>
@@ -31,7 +32,7 @@
 
     <!-- Strike Modal -->
     <div aria-hidden="{!not(v.showingModal)}" class="{!if(v.showingModal, '', 'slds-hide')}">
-        <div id="modal" aura:id="modal" role="dialog" tabindex="{!if(showingModal, 0, -1)}" aria-labelledby="{!'header-' + v.modalHeaderId}" class="{!if(v.fadeIn, 'slds-fade-in-open', '') + ' slds-modal ' + if(empty(v.variant), '', 'slds-modal--prompt')}">
+        <div id="modal" aura:id="modal" role="dialog" tabindex="{!if(showingModal, 0, -1)}" aria-labelledby="{!'header-' + v.modalHeaderId}" class="{!if(v.fadeIn, 'slds-fade-in-open', '') + ' slds-modal ' + if(empty(v.variant), '', 'slds-modal--prompt') + if(empty(v.size), '', ' slds-modal--' +v.size)}">
             <div class="slds-modal__container">
                 <div class="{!'slds-modal__header' + if(empty(v.variant), '', ' slds-theme--alert-texture slds-theme--' + v.variant) + if(v.showHeader == false, ' slds-modal__header--empty', '')}">
                     <lightning:buttonIcon onclick="{!c.hide}" iconName="utility:close" alternativeText="Close" name="Close" size="large" variant="bare" class="slds-button slds-modal__close slds-button--icon-inverse"/>


### PR DESCRIPTION
Hey Strike Team!

Not sure if I'm missing anything big for testing this but it's a simple change. I wanted to have support for large modals in my project (without overriding CSS), so I created this simple change. I'm not a big OSS contributor so hopefully I'm not missing anything big here!

- Supply a "size" attribute (optional). Right now the only supported SLDS modal size variant is "large"
- This will add the `slds-modal_large` class onto the `div.slds-modal` element

I only tested that it works with it on and off. I did not see anything else that would be impacted by this feature, but let me know if you would like to see anything else! Thanks!