### PR TITLE
Update strike_lookupHelper.js

### DIFF
--- a/aura/strike_lookup/strike_lookupHelper.js
+++ b/aura/strike_lookup/strike_lookupHelper.js
@@ -243,6 +243,11 @@ License: BSD 3-Clause License*/
 
         if (overrideNewEvent) {
             addRecordEvent = component.getEvent('strike_evt_addNewRecord');
+            
+            // we need to detect which one is clicked. we can use event parameter.
+            addRecordEvent.setParams({
+                data: component.get('v.object')
+            });
         } else {
             addRecordEvent = $A.get('e.force:createRecord');
 


### PR DESCRIPTION
If we can use event parameter, we can detect which one is clicked for a new record creation. 

ps: in case we have more than one lookups in our component.