### PR TITLE
Strike Lookup Enhancement - Allow Search by Id and Multiple field Search

### DIFF
--- a/aura/strike_lookup/strike_lookup.cmp
+++ b/aura/strike_lookup/strike_lookup.cmp
@@ -1,212 +1,212 @@
 <!--
-Strike by Appiphony
+	Strike by Appiphony
 
-Version: 1.0.0
-Website: http://www.lightningstrike.io
-GitHub: https://github.com/appiphony/Strike-Components
-License: BSD 3-Clause License
+	Version: 1.0.0
+	Website: http://www.lightningstrike.io
+	GitHub: https://github.com/appiphony/Strike-Components
+	License: BSD 3-Clause License
 -->
 <aura:component controller="strike_lookupController" access="global">
-    <!-- Required -->
-    <aura:attribute name="label" type="String" required="true" description="String value displayed above the menu used to describe the component"/>
-    <aura:attribute name="object" type="String" required="true" description="String value that determines which records to search"/>
-    <aura:attribute name="searchField" type="String" required="true" description="String value that determines which field on the object will be displayed and searched against"/>
+	<!-- Required -->
+	<aura:attribute name="label" type="String" required="true" description="String value displayed above the menu used to describe the component"/>
+	<aura:attribute name="object" type="String" required="true" description="String value that determines which records to search"/>
+	<aura:attribute name="searchField" type="String" required="true" description="String value that determines which field on the object will be displayed and searched against"/>
+	<aura:attribute name="searchFields" type="String" required="false" description="Comma Separated Name of fields which will be searched with OR Condition with mandatory searchField" />
+	<aura:attribute name="helpText" type="String" description="String value when hovering over the help box"/>
+	<aura:attribute name="helpTextPlacement" type="String" default="auto top" description="Determines position of the helpText"/>
+	<aura:attribute name="class" type="String" description="A CSS class that will be applied to the outer element. This style is in addition to base classes associated with the component"/>
+	<aura:attribute name="placeholder" type="String" description="String value that will appear when no record is selected"/>
+	<aura:attribute name="value" type="String" description="String value that holds the Id of the selected record"/>
 
-    <aura:attribute name="helpText" type="String" description="String value when hovering over the help box"/>
-    <aura:attribute name="helpTextPlacement" type="String" default="auto top" description="Determines position of the helpText"/>
-    <aura:attribute name="class" type="String" description="A CSS class that will be applied to the outer element. This style is in addition to base classes associated with the component"/>
-    <aura:attribute name="placeholder" type="String" description="String value that will appear when no record is selected"/>
-    <aura:attribute name="value" type="String" description="String value that holds the Id of the selected record"/>
+	<aura:attribute name="iconName" type="String" description="String value that determines the icon name or path"/>
+	<aura:attribute name="customIcon" type="Boolean" description="Determines whether the icon is custom or standard"/>
 
-    <aura:attribute name="iconName" type="String" description="String value that determines the icon name or path"/>
-    <aura:attribute name="customIcon" type="Boolean" description="Determines whether the icon is custom or standard"/>
+	<!-- Query -->
+	<aura:attribute name="subtitleField" type="String" description="String value that determines which field to display second from search results"/>
+	<aura:attribute name="filter" type="String" description="String value that determines how the SOQL search will be filtered"/>
+	<aura:attribute name="order" type="String" description="String value that determines how the SOQL search will be ordered"/>
+	<aura:attribute name="limit" type="String" description="String value that determines how many records are returned in the SOQL search"/>
 
-    <!-- Query -->
-    <aura:attribute name="subtitleField" type="String" description="String value that determines which field to display second from search results"/>
-    <aura:attribute name="filter" type="String" description="String value that determines how the SOQL search will be filtered"/>
-    <aura:attribute name="order" type="String" description="String value that determines how the SOQL search will be ordered"/>
-    <aura:attribute name="limit" type="String" description="String value that determines how many records are returned in the SOQL search"/>
+	<!-- Messages -->
+	<aura:attribute name="loadingMessage" type="String" default="Loading..." description="String value that will appear when the component is initializing"/>
+	<aura:attribute name="searchingMessage" type="String" default="Searching..." description="String value that will appear when the component is searching"/>
+	<aura:attribute name="noResultsMessage" type="String" default="No results found for {0}" description="String value that will appear when the component finds 0 results"/>
+	<aura:attribute name="errorMessage" type="String" description="String value displayed when the input is in an error state"/>
 
-    <!-- Messages -->
-    <aura:attribute name="loadingMessage" type="String" default="Loading..." description="String value that will appear when the component is initializing"/>
-    <aura:attribute name="searchingMessage" type="String" default="Searching..." description="String value that will appear when the component is searching"/>
-    <aura:attribute name="noResultsMessage" type="String" default="No results found for {0}" description="String value that will appear when the component finds 0 results"/>
-    <aura:attribute name="errorMessage" type="String" description="String value displayed when the input is in an error state"/>
+	<!-- New Records -->
+	<aura:attribute name="allowNewRecords" type="Boolean" description="Determines whether the New Record option is displayed"/>
+	<aura:attribute name="overrideNewEvent" type="Boolean" description="Determines whether the standard new event should fire"/>
 
-    <!-- New Records -->
-    <aura:attribute name="allowNewRecords" type="Boolean" description="Determines whether the New Record option is displayed"/>
-    <aura:attribute name="overrideNewEvent" type="Boolean" description="Determines whether the standard new event should fire"/>
+	<aura:attribute name="showRecentRecords" type="Boolean" description="Determines whether the five most recently viewed records will be displayed when the search field is empty"/>
 
-    <aura:attribute name="showRecentRecords" type="Boolean" description="Determines whether the five most recently viewed records will be displayed when the search field is empty"/>
+	<aura:attribute name="disabled" type="Boolean" description="Determines whether the input is disabled"/>
+	<aura:attribute name="required" type="Boolean" description="Determines whether a '*' is displayed on the component"/>
+	<aura:attribute name="error" type="Boolean" description="Determines whether the input is in an error state"/>
 
-    <aura:attribute name="disabled" type="Boolean" description="Determines whether the input is disabled"/>
-    <aura:attribute name="required" type="Boolean" description="Determines whether a '*' is displayed on the component"/>
-    <aura:attribute name="error" type="Boolean" description="Determines whether the input is in an error state"/>
+	<!-- Methods -->
+	<aura:method name="showError" action="{!c.showError}" description="A method which triggers the error state">
+		<aura:attribute name="errorMessage" type="String"/>
+	</aura:method>
+	<aura:method name="hideError" action="{!c.hideError}" description="A method which removes the error state"/>
 
-    <!-- Methods -->
-    <aura:method name="showError" action="{!c.showError}" description="A method which triggers the error state">
-        <aura:attribute name="errorMessage" type="String"/>
-    </aura:method>
-    <aura:method name="hideError" action="{!c.hideError}" description="A method which removes the error state"/>
+	<!-- Internal -->
+	<aura:attribute name="focusIndex" type="Integer" description="Integer value that determines which record is focused" access="private"/>
+	<aura:attribute name="idNumber" type="Integer" description="Random id assigned to pair labels with inputs" access="private"/>
+	<aura:attribute name="initCallsRunning" type="Integer" default="{!0}" description="Integer value that determines how many calls are running during init" access="private"/>
+	<aura:attribute name="lastSearchTerm" type="String" description="String value that holds the last searched term" access="private"/>
+	<aura:attribute name="openMenu" type="Boolean" default="{!false}" description="Determines whether the menu is open" access="private"/>
+	<aura:attribute name="objectLabel" type="String" description="String value that holds the label of the object" access="private"/>
+	<aura:attribute name="recentRecords" type="Object[]" description="List of the most recent records" access="private"/>
+	<aura:attribute name="records" type="Object[]" description="List of records returned from the SOQL search" access="private"/>
+	<aura:attribute name="searching" type="Boolean" description="Boolean value marked when searching" access="private"/>
+	<aura:attribute name="searchTimeout" type="Object" description="Object that holds the search Timeout" access="private"/>
+	<aura:attribute name="valueLabel" type="String" description="String value that holds the searchField of the selected record"/>
+	<aura:attribute name="valueSublabel" type="String" description="String value that holds the subtitleField of the selected record" access="private"/>
+	<aura:attribute name="isMobile" type="Boolean" default="{!false}" description="Determines if the user is in Salesforce1" access="private"/>
 
-    <!-- Internal -->
-    <aura:attribute name="focusIndex" type="Integer" description="Integer value that determines which record is focused" access="private"/>
-    <aura:attribute name="idNumber" type="Integer" description="Random id assigned to pair labels with inputs" access="private"/>
-    <aura:attribute name="initCallsRunning" type="Integer" default="{!0}" description="Integer value that determines how many calls are running during init" access="private"/>
-    <aura:attribute name="lastSearchTerm" type="String" description="String value that holds the last searched term" access="private"/>
-    <aura:attribute name="openMenu" type="Boolean" default="{!false}" description="Determines whether the menu is open" access="private"/>
-    <aura:attribute name="objectLabel" type="String" description="String value that holds the label of the object" access="private"/>
-    <aura:attribute name="recentRecords" type="Object[]" description="List of the most recent records" access="private"/>
-    <aura:attribute name="records" type="Object[]" description="List of records returned from the SOQL search" access="private"/>
-    <aura:attribute name="searching" type="Boolean" description="Boolean value marked when searching" access="private"/>
-    <aura:attribute name="searchTimeout" type="Object" description="Object that holds the search Timeout" access="private"/>
-    <aura:attribute name="valueLabel" type="String" description="String value that holds the searchField of the selected record"/>
-    <aura:attribute name="valueSublabel" type="String" description="String value that holds the subtitleField of the selected record" access="private"/>
-    <aura:attribute name="isMobile" type="Boolean" default="{!false}" description="Determines if the user is in Salesforce1" access="private"/>
+	<!-- Event registration and handlers -->
+	<aura:handler name="init" value="{!this}" action="{!c.onInit}"/>
+	<aura:handler name="change" value="{!v.focusIndex}" action="{!c.handleFocusIndexChange}"/>
+	<aura:handler name="change" value="{!v.value}" action="{!c.handleValueChange}"/>
 
-    <!-- Event registration and handlers -->
-    <aura:handler name="init" value="{!this}" action="{!c.onInit}"/>
-    <aura:handler name="change" value="{!v.focusIndex}" action="{!c.handleFocusIndexChange}"/>
-    <aura:handler name="change" value="{!v.value}" action="{!c.handleValueChange}"/>
+	<aura:handler name="change" value="{!v.object}" action="{!c.handleObjectChange}"/>
+	<aura:handler name="change" value="{!v.searchField}" action="{!c.handleSearchfieldChange}"/>
+	<aura:handler name="change" value="{!v.subtitleField}" action="{!c.handleSubtitlefieldChange}"/>
+	<aura:handler name="change" value="{!v.filter}" action="{!c.handleFilterChange}"/>
+	<aura:handler name="change" value="{!v.order}" action="{!c.handleOrderChange}"/>
+	<aura:handler name="change" value="{!v.limit}" action="{!c.handleLimitChange}"/>
 
-    <aura:handler name="change" value="{!v.object}" action="{!c.handleObjectChange}"/>
-    <aura:handler name="change" value="{!v.searchField}" action="{!c.handleSearchfieldChange}"/>
-    <aura:handler name="change" value="{!v.subtitleField}" action="{!c.handleSubtitlefieldChange}"/>
-    <aura:handler name="change" value="{!v.filter}" action="{!c.handleFilterChange}"/>
-    <aura:handler name="change" value="{!v.order}" action="{!c.handleOrderChange}"/>
-    <aura:handler name="change" value="{!v.limit}" action="{!c.handleLimitChange}"/>
+	<aura:registerEvent name="strike_evt_addNewRecord" type="c:strike_evt" description="Fires an event that notifies when the strike_evt_addNewRecord button is pressed"/>
+	<aura:dependency resource="force:createRecord" type="EVENT"/>
 
-    <aura:registerEvent name="strike_evt_addNewRecord" type="c:strike_evt" description="Fires an event that notifies when the strike_evt_addNewRecord button is pressed"/>
-    <aura:dependency resource="force:createRecord" type="EVENT"/>
+	<!-- Strike Lookup -->
+	<ui:scrollerWrapper aura:id="lookup" class="{!'slds-form-element slds-lookup slds-is-open ' + if(v.error, 'slds-has-error ', '') + if(v.isMobile, 'sl-lookup--mobile ', '') + if(v.openMenu, 'sl-lookup--open ', '') + v.class}">
+		<label class="slds-form-element__label" for="{!'strike-lookup-' + v.idNumber}">
+			<aura:if isTrue="{!v.required}">
+				<abbr class="slds-required" title="required">*</abbr>
+			</aura:if>
+			{!v.label}  
+		</label>
+		<aura:if isTrue="{!not(empty(v.helpText))}">
+			<c:strike_tooltip placement="{!v.helpTextPlacement}" text="{!v.helpText}" class="sl-help-text-icon">
+				<lightning:icon iconName="utility:info" size="xx-small"/>
+			</c:strike_tooltip>
+		</aura:if>
+		<div class="{!'slds-form-element__control slds-input-has-icon slds-input-has-icon--right' + if(v.disabled, ' sl-disabled', '')}" onclick="{!c.cancelLookup}">
+			<div class="{!'slds-pill_container' + if(or(not(empty(v.value)), greaterthan(v.initCallsRunning, 0)), '', ' slds-hide')}">
+				<span class="{!'slds-pill slds-size--1-of-1' + if(greaterthan(v.initCallsRunning, 0), ' sl-pill--loading', '')}">
+					<aura:if isTrue="{!and(not(empty(v.iconName)), equals(v.initCallsRunning, 0))}">
+						<aura:if isTrue="{!v.customIcon}">
+							<span class="slds-icon_container">
+								<c:strike_svg aura:id="svgComp" xlinkHref="{!v.iconName}" ariaHidden="true" class="slds-icon-text-default slds-icon slds-icon--small slds-pill__icon_container"/>
+							</span>
+							<aura:set attribute="else">
+								<lightning:icon class="slds-pill__icon_container" iconName="{!v.iconName}" size="small"/>
+							</aura:set>
+						</aura:if>
+					</aura:if>
+					<span class="slds-pill__label sl-pill__label" title="{!if(v.initCallsRunning > 0, v.loadingMessage, v.valueLabel)}">{!if(v.initCallsRunning > 0, v.loadingMessage, v.valueLabel)}</span>
+					<button class="{!'slds-button slds-button--icon slds-pill__remove' + if(or(v.disabled, greaterthan(v.initCallsRunning, 0)), ' slds-hide', '')}" title="Remove" onclick="{!c.handlePillClick}">
+						<lightning:icon iconName="utility:close" size="xx-small"/>
+					</button>
+				</span>
+			</div>
+			<div class="{!'sl-lookup__input_container' + if(v.isMobile == true, ' slds-grid slds-grid--pull-padded-xx-small', '') + if(and(equals(v.initCallsRunning, 0), empty(v.value)), '', ' slds-hide')}">
+				<div class="{!'sl-lookup__input' + if(v.isMobile == true, ' slds-col slds-p-horizontal--xx-small', '')}">
+					<lightning:icon iconName="utility:search" size="x-small" class="sl-search-icon"/>
+					<input
+						aura:id="lookupInput"
+						id="{!'strike-lookup-' + v.idNumber}"
+						name="{!'input-' + v.idNumber}"
+						class="slds-lookup__search-input slds-input js-template-lookup"
+						type="text"
+						aria-autocomplete="list"
+						role="combobox"
+						aria-expanded="false"
+						placeholder="{!v.placeholder}"
+						onclick="{!c.handleInputClick}"
+						onfocus="{!c.handleInputFocus}"
+						onkeydown="{!c.handleInputKeyDown}"
+						onkeyup="{!c.handleInputKeyUp}"
+						onkeypress="{!c.handleInputKeyPress}"
+						disabled='{!v.disabled}'/>
+				</div>
+				<aura:if isTrue="{!v.isMobile}">
+					<div class="sl-lookup--mobile__cancel slds-col slds-no-flex slds-p-horizontal--xx-small">
+						<button class="slds-button slds-button--neutral" onclick="{!c.cancelLookup}">Cancel</button>
+					</div>
+				</aura:if>
+			</div>
+			<div class="{!if(v.searching, 'slds-lookup__menu', 'slds-hide')}" role="listbox" onclick="{!c.handleSearchingClick}">
+				<ul class="slds-lookup__list" role="listbox">
+					<li role="presentation">
+						<span class="slds-lookup__item-action slds-media sl-searching" role="option">
+							<div class="slds-media__body">
+								<div class="slds-lookup__result-text">{!v.searchingMessage}</div>
+							</div>
+						</span>
+					</li>
+				</ul>
+			</div>
+			<div class="{!if(and(v.searching == false, v.openMenu), 'slds-lookup__menu', 'slds-hide')}" role="listbox">
+				<div class="{!if(or(v.records == null, v.records.length == 0), '', 'slds-hide')}">
+					<ul class="slds-lookup__list" role="listbox">
+						<li role="presentation">
+							<span class="slds-lookup__item-action slds-media sl-no-results" role="option">
+								<div class="slds-media__body">
+									<div class="slds-lookup__result-text">
+										{!format(v.noResultsMessage, '"' + v.lastSearchTerm + '"')}
+									</div>
+								</div>
+							</span>
+						</li>
+					</ul>
+				</div>
+				<ul aura:id="lookupMenu" class="{!if(v.searching, 'slds-hide', 'slds-lookup__list')}" role="listbox">
+					<aura:iteration items="{!v.records}" var="record" indexVar="index">
+						<li role="presentation" class="{!if(index == v.focusIndex, 'slds-has-focus', '')}" data-index="{!index}" onclick="{!c.handleRecordClick}">
+							<span class="slds-lookup__item-action slds-media" role="option">
+								<aura:if isTrue="{!and(not(empty(v.iconName)), not(v.customIcon))}">
+									<lightning:icon class="slds-media__figure" iconName="{!v.iconName}" size="small"/>
+								</aura:if>
+								<aura:if isTrue="{!v.customIcon}">
+									<span class="slds-icon_container">
+										<c:strike_svg aura:id="svgComp" xlinkHref="{!v.iconName}" ariaHidden="true" class="slds-icon-text-default slds-media__figure slds-icon slds-icon--x-small"/>
+									</span>
+								</aura:if>
+								<div class="slds-media__body">
+									<div class="slds-lookup__result-text">{!record.label}</div>
+									<span class="{!'slds-lookup__result-meta slds-text-body--small' + if(empty(record.sublabel, ' slds-hide', ''))}">{!record.sublabel}</span>
+								</div>
+							</span>
+						</li>
+					</aura:iteration>
+					<aura:if isTrue="{!v.allowNewRecords}">
+						<li role="presentation" class="{!'sl-lookup__new' + if(index == -1, ' slds-has-focus', '')}" onclick="{!c.handleNewRecordClick}">
+							<span class="slds-lookup__item-action slds-lookup__item-action--label" role="option">
+								<lightning:icon iconName="utility:add" size="x-small"/>
+								<span class="slds-truncate">Add New {!v.objectLabel}</span>
+							</span>
+						</li>
+					</aura:if>
+				</ul>
+			</div>
+		</div>
 
-    <!-- Strike Lookup -->
-    <ui:scrollerWrapper aura:id="lookup" class="{!'slds-form-element slds-lookup slds-is-open ' + if(v.error, 'slds-has-error ', '') + if(v.isMobile, 'sl-lookup--mobile ', '') + if(v.openMenu, 'sl-lookup--open ', '') + v.class}">
-        <label class="slds-form-element__label" for="{!'strike-lookup-' + v.idNumber}">
-            <aura:if isTrue="{!v.required}">
-                <abbr class="slds-required" title="required">*</abbr>
-            </aura:if>
-            {!v.label}  
-        </label>
-        <aura:if isTrue="{!not(empty(v.helpText))}">
-            <c:strike_tooltip placement="{!v.helpTextPlacement}" text="{!v.helpText}" class="sl-help-text-icon">
-                <lightning:icon iconName="utility:info" size="xx-small"/>
-            </c:strike_tooltip>
-        </aura:if>
-        <div class="{!'slds-form-element__control slds-input-has-icon slds-input-has-icon--right' + if(v.disabled, ' sl-disabled', '')}" onclick="{!c.cancelLookup}">
-            <div class="{!'slds-pill_container' + if(or(not(empty(v.value)), greaterthan(v.initCallsRunning, 0)), '', ' slds-hide')}">
-                <span class="{!'slds-pill slds-size--1-of-1' + if(greaterthan(v.initCallsRunning, 0), ' sl-pill--loading', '')}">
-                    <aura:if isTrue="{!and(not(empty(v.iconName)), equals(v.initCallsRunning, 0))}">
-                        <aura:if isTrue="{!v.customIcon}">
-                            <span class="slds-icon_container">
-                                <c:strike_svg aura:id="svgComp" xlinkHref="{!v.iconName}" ariaHidden="true" class="slds-icon-text-default slds-icon slds-icon--small slds-pill__icon_container"/>
-                            </span>
-                            <aura:set attribute="else">
-                                <lightning:icon class="slds-pill__icon_container" iconName="{!v.iconName}" size="small"/>
-                            </aura:set>
-                        </aura:if>
-                    </aura:if>
-                    <span class="slds-pill__label sl-pill__label" title="{!if(v.initCallsRunning > 0, v.loadingMessage, v.valueLabel)}">{!if(v.initCallsRunning > 0, v.loadingMessage, v.valueLabel)}</span>
-                    <button class="{!'slds-button slds-button--icon slds-pill__remove' + if(or(v.disabled, greaterthan(v.initCallsRunning, 0)), ' slds-hide', '')}" title="Remove" onclick="{!c.handlePillClick}">
-                        <lightning:icon iconName="utility:close" size="xx-small"/>
-                    </button>
-                </span>
-            </div>
-            <div class="{!'sl-lookup__input_container' + if(v.isMobile == true, ' slds-grid slds-grid--pull-padded-xx-small', '') + if(and(equals(v.initCallsRunning, 0), empty(v.value)), '', ' slds-hide')}">
-                <div class="{!'sl-lookup__input' + if(v.isMobile == true, ' slds-col slds-p-horizontal--xx-small', '')}">
-                    <lightning:icon iconName="utility:search" size="x-small" class="sl-search-icon"/>
-                    <input
-                        aura:id="lookupInput"
-                        id="{!'strike-lookup-' + v.idNumber}"
-                        name="{!'input-' + v.idNumber}"
-                        class="slds-lookup__search-input slds-input js-template-lookup"
-                        type="text"
-                        aria-autocomplete="list"
-                        role="combobox"
-                        aria-expanded="false"
-                        placeholder="{!v.placeholder}"
-                        onclick="{!c.handleInputClick}"
-                        onfocus="{!c.handleInputFocus}"
-                        onkeydown="{!c.handleInputKeyDown}"
-                        onkeyup="{!c.handleInputKeyUp}"
-                        onkeypress="{!c.handleInputKeyPress}"
-                        disabled='{!v.disabled}'/>
-                </div>
-                <aura:if isTrue="{!v.isMobile}">
-                    <div class="sl-lookup--mobile__cancel slds-col slds-no-flex slds-p-horizontal--xx-small">
-                        <button class="slds-button slds-button--neutral" onclick="{!c.cancelLookup}">Cancel</button>
-                    </div>
-                </aura:if>
-            </div>
-            <div class="{!if(v.searching, 'slds-lookup__menu', 'slds-hide')}" role="listbox" onclick="{!c.handleSearchingClick}">
-                <ul class="slds-lookup__list" role="listbox">
-                    <li role="presentation">
-                        <span class="slds-lookup__item-action slds-media sl-searching" role="option">
-                            <div class="slds-media__body">
-                                <div class="slds-lookup__result-text">{!v.searchingMessage}</div>
-                            </div>
-                        </span>
-                    </li>
-                </ul>
-            </div>
-            <div class="{!if(and(v.searching == false, v.openMenu), 'slds-lookup__menu', 'slds-hide')}" role="listbox">
-                <div class="{!if(or(v.records == null, v.records.length == 0), '', 'slds-hide')}">
-                    <ul class="slds-lookup__list" role="listbox">
-                        <li role="presentation">
-                            <span class="slds-lookup__item-action slds-media sl-no-results" role="option">
-                                <div class="slds-media__body">
-                                    <div class="slds-lookup__result-text">
-                                        {!format(v.noResultsMessage, '"' + v.lastSearchTerm + '"')}
-                                    </div>
-                                </div>
-                            </span>
-                        </li>
-                    </ul>
-                </div>
-                <ul aura:id="lookupMenu" class="{!if(v.searching, 'slds-hide', 'slds-lookup__list')}" role="listbox">
-                    <aura:iteration items="{!v.records}" var="record" indexVar="index">
-                        <li role="presentation" class="{!if(index == v.focusIndex, 'slds-has-focus', '')}" data-index="{!index}" onclick="{!c.handleRecordClick}">
-                            <span class="slds-lookup__item-action slds-media" role="option">
-                                <aura:if isTrue="{!and(not(empty(v.iconName)), not(v.customIcon))}">
-                                    <lightning:icon class="slds-media__figure" iconName="{!v.iconName}" size="small"/>
-                                </aura:if>
-                                <aura:if isTrue="{!v.customIcon}">
-                                    <span class="slds-icon_container">
-                                        <c:strike_svg aura:id="svgComp" xlinkHref="{!v.iconName}" ariaHidden="true" class="slds-icon-text-default slds-media__figure slds-icon slds-icon--x-small"/>
-                                    </span>
-                                </aura:if>
-                                <div class="slds-media__body">
-                                    <div class="slds-lookup__result-text">{!record.label}</div>
-                                    <span class="{!'slds-lookup__result-meta slds-text-body--small' + if(empty(record.sublabel, ' slds-hide', ''))}">{!record.sublabel}</span>
-                                </div>
-                            </span>
-                        </li>
-                    </aura:iteration>
-                    <aura:if isTrue="{!v.allowNewRecords}">
-                        <li role="presentation" class="{!'sl-lookup__new' + if(index == -1, ' slds-has-focus', '')}" onclick="{!c.handleNewRecordClick}">
-                            <span class="slds-lookup__item-action slds-lookup__item-action--label" role="option">
-                                <lightning:icon iconName="utility:add" size="x-small"/>
-                                <span class="slds-truncate">Add New {!v.objectLabel}</span>
-                            </span>
-                        </li>
-                    </aura:if>
-                </ul>
-            </div>
-        </div>
-
-        <aura:if isTrue="{!and(v.error, not(empty(v.errorMessage)))}">
-            <div class="slds-form-element__help">{!v.errorMessage}</div>
-        </aura:if>
-    </ui:scrollerWrapper>
+		<aura:if isTrue="{!and(v.error, not(empty(v.errorMessage)))}">
+			<div class="slds-form-element__help">{!v.errorMessage}</div>
+		</aura:if>
+	</ui:scrollerWrapper>
 </aura:component>
 <!--
-Copyright 2017 Appiphony, LLC
+	Copyright 2017 Appiphony, LLC
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
-products derived from this software without specific prior written permission.
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+	3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+	products derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->

--- a/aura/strike_lookup/strike_lookupController.js
+++ b/aura/strike_lookup/strike_lookupController.js
@@ -1,242 +1,244 @@
 /*Strike by Appiphony
 
-Version: 1.0.0
-Website: http://www.lightningstrike.io
-GitHub: https://github.com/appiphony/Strike-Components
-License: BSD 3-Clause License*/
+	Version: 1.0.0
+	Website: http://www.lightningstrike.io
+	GitHub: https://github.com/appiphony/Strike-Components
+	License: BSD 3-Clause License
+*/
 ({
-    onInit: function(component, event, helper) {
-        component.handleClick = $A.getCallback(function() {
-            if (!component.isValid()) {
-                window.removeEventListener('click', component.handleClick);
+	onInit: function(component, event, helper) {
+		component.handleClick = $A.getCallback(function() {
+			if (!component.isValid()) {
+				window.removeEventListener('click', component.handleClick);
 
-                return;
-            }
+				return;
+			}
 
-            helper.closeMenu(component, event, helper);
-        });
+			helper.closeMenu(component, event, helper);
+		});
 
-        window.addEventListener('click', component.handleClick);
+		window.addEventListener('click', component.handleClick);
 
-        component.set('v.initCallsRunning', 3);
+		component.set('v.initCallsRunning', 3);
 
-        helper.getRecentRecords(component, event, helper);
-        helper.getRecordByValue(component, event, helper);
-        helper.getRecordLabel(component, event, helper);
+		helper.getRecentRecords(component, event, helper);
+		helper.getRecordByValue(component, event, helper);
+		helper.getRecordLabel(component, event, helper);
 
-        var randomNumber = Math.floor(1000 + Math.random() * 9000);
+		var randomNumber = Math.floor(1000 + Math.random() * 9000);
 
-        component.set('v.idNumber', randomNumber);
-        
-        component.set('v.isMobile', $A.get('$Browser.formFactor') === 'DESKTOP' ? false : true);
-    },
-    handleInputClick: function(component, event, helper) {
-        event.stopPropagation();
-    },
-    handleSearchingClick: function(component, event, helper) {
-        component.set('v.searching', false);
-    },
-    handleInputFocus: function(component, event, helper) {
-        $A.util.addClass(component.find('lookup'), 'sl-lookup--open');
-        
-        if (component.get('v.disabled')) {
-            return;
-        }
+		component.set('v.idNumber', randomNumber);
+		
+		component.set('v.isMobile', $A.get('$Browser.formFactor') === 'DESKTOP' ? false : true);
+	},
+	handleInputClick: function(component, event, helper) {
+		event.stopPropagation();
+	},
+	handleSearchingClick: function(component, event, helper) {
+		component.set('v.searching', false);
+	},
+	handleInputFocus: function(component, event, helper) {
+		$A.util.addClass(component.find('lookup'), 'sl-lookup--open');
+		
+		if (component.get('v.disabled')) {
+			return;
+		}
 
-        helper.getRecordsBySearchTerm(component, event, helper);
-    },
-    cancelLookup: function(component, event, helper) {
-        helper.closeMobileLookup(component, event, helper);
-    },
-    handleInputKeyDown: function(component, event, helper) {
-        if (component.get('v.disabled')) {
-            return;
-        }
+		helper.getRecordsBySearchTerm(component, event, helper);
+	},
+	cancelLookup: function(component, event, helper) {
+		helper.closeMobileLookup(component, event, helper);
+	},
+	handleInputKeyDown: function(component, event, helper) {
+		if (component.get('v.disabled')) {
+			return;
+		}
 
-        var KEYCODE_TAB = 9;
+		var KEYCODE_TAB = 9;
 
-        var keyCode = event.which || event.keyCode || 0;
+		var keyCode = event.which || event.keyCode || 0;
 
-        if (keyCode === KEYCODE_TAB) {
-            helper.closeMenu(component, event, helper);
-        }
-    },
-    handleInputKeyPress: function(component, event, helper) {
-        if (component.get('v.disabled')) {
-            return;
-        }
-    },
-    handleInputKeyUp: function(component, event, helper) {
-        if (component.get('v.disabled')) {
-            return;
-        }
+		if (keyCode === KEYCODE_TAB) {
+			helper.closeMenu(component, event, helper);
+		}
+	},
+	handleInputKeyPress: function(component, event, helper) {
+		if (component.get('v.disabled')) {
+			return;
+		}
+	},
+	handleInputKeyUp: function(component, event, helper) {
+		if (component.get('v.disabled')) {
+			return;
+		}
 
-        var KEYCODE_ENTER = 13;
-        var KEYCODE_UP = 38;
-        var KEYCODE_DOWN = 40;
+		var KEYCODE_ENTER = 13;
+		var KEYCODE_UP = 38;
+		var KEYCODE_DOWN = 40;
 
-        var keyCode = event.which || event.keyCode || 0;
+		var keyCode = event.which || event.keyCode || 0;
 
-        if (keyCode === KEYCODE_ENTER) {
-            helper.updateValueByFocusIndex(component, event, helper);
-        } else if (keyCode === KEYCODE_UP) {
-            helper.moveRecordFocusUp(component, event, helper);
-        } else if (keyCode === KEYCODE_DOWN) {
-            helper.moveRecordFocusDown(component, event, helper);
-        } else {
-            helper.getRecordsBySearchTerm(component, event, helper);
-        }
-    },
+		if (keyCode === KEYCODE_ENTER) {
+			helper.updateValueByFocusIndex(component, event, helper);
+		} else if (keyCode === KEYCODE_UP) {
+			helper.moveRecordFocusUp(component, event, helper);
+		} else if (keyCode === KEYCODE_DOWN) {
+			helper.moveRecordFocusDown(component, event, helper);
+		} else {
+			helper.getRecordsBySearchTerm(component, event, helper);
+		}
+	},
 
-    handleRecordClick: function(component, event, helper) {
-        event.preventDefault();
-        event.stopPropagation();
+	handleRecordClick: function(component, event, helper) {
+		event.preventDefault();
+		event.stopPropagation();
 
-        var focusIndex = event.currentTarget.dataset.index;
+		var focusIndex = event.currentTarget.dataset.index;
 
-        component.set('v.focusIndex', focusIndex);
+		component.set('v.focusIndex', focusIndex);
 
-        helper.updateValueByFocusIndex(component, event, helper);
-    },
-    handleNewRecordClick: function(component, event, helper) {
-        event.preventDefault();
-        event.stopPropagation();
+		helper.updateValueByFocusIndex(component, event, helper);
+	},
+	handleNewRecordClick: function(component, event, helper) {
+		event.preventDefault();
+		event.stopPropagation();
 
-        helper.addNewRecord(component, event, helper);
-    },
-    handlePillClick: function(component, event, helper) {
-        event.preventDefault();
-        event.stopPropagation();
+		helper.addNewRecord(component, event, helper);
+	},
+	handlePillClick: function(component, event, helper) {
+		event.preventDefault();
+		event.stopPropagation();
 
-        component.set('v.value', '');
+		component.set('v.value', '');
 
-        helper.getRecordsBySearchTerm(component, event, helper);
+		helper.getRecordsBySearchTerm(component, event, helper);
 
-        window.setTimeout($A.getCallback(function() {
-            component.find('lookupInput').getElement().focus();
-        }), 1);
-    },
+		window.setTimeout($A.getCallback(function() {
+			component.find('lookupInput').getElement().focus();
+		}), 1);
+	},
 
-    handleFocusIndexChange: function(component, event, helper) {
-        var focusIndex = component.get('v.focusIndex');
-        var lookupMenu = component.find('lookupMenu').getElement();
+	handleFocusIndexChange: function(component, event, helper) {
+		var focusIndex = component.get('v.focusIndex');
+		var lookupMenu = component.find('lookupMenu').getElement();
 
-        if (!$A.util.isEmpty(lookupMenu)) {
-            var options = lookupMenu.getElementsByTagName('li');
-            var focusScrollTop = 0;
-            var focusScrollBottom = 0;
+		if (!$A.util.isEmpty(lookupMenu)) {
+			var options = lookupMenu.getElementsByTagName('li');
+			var focusScrollTop = 0;
+			var focusScrollBottom = 0;
 
-            for (var i = 0; i < options.length; i++) {
-                var optionSpan = options[i].getElementsByTagName('span')[0];
+			for (var i = 0; i < options.length; i++) {
+				var optionSpan = options[i].getElementsByTagName('span')[0];
 
-                if (i === focusIndex) {
-                    $A.util.addClass(optionSpan, 'slds-has-focus');
-                } else {
-                    if (i < focusIndex) {
-                        focusScrollTop += options[i].scrollHeight;
-                    }
+				if (i === focusIndex) {
+					$A.util.addClass(optionSpan, 'slds-has-focus');
+				} else {
+					if (i < focusIndex) {
+						focusScrollTop += options[i].scrollHeight;
+					}
 
-                    $A.util.removeClass(optionSpan, 'slds-has-focus');
-                }
-            }
+					$A.util.removeClass(optionSpan, 'slds-has-focus');
+				}
+			}
 
-            if (focusIndex !== null) {
-                focusScrollBottom = focusScrollTop + options[focusIndex].scrollHeight;
-            }
+			if (focusIndex !== null) {
+				focusScrollBottom = focusScrollTop + options[focusIndex].scrollHeight;
+			}
 
-            if (focusScrollTop < lookupMenu.scrollTop) {
-                lookupMenu.scrollTop = focusScrollTop;
-            } else if (focusScrollBottom > lookupMenu.scrollTop + lookupMenu.clientHeight) {
-                lookupMenu.scrollTop = focusScrollBottom - lookupMenu.clientHeight;
-            }
-        }
-    },
-    handleValueChange: function(component, event, helper) {
-        var value = component.get('v.value');
+			if (focusScrollTop < lookupMenu.scrollTop) {
+				lookupMenu.scrollTop = focusScrollTop;
+			} else if (focusScrollBottom > lookupMenu.scrollTop + lookupMenu.clientHeight) {
+				lookupMenu.scrollTop = focusScrollBottom - lookupMenu.clientHeight;
+			}
+		}
+	},
+	handleValueChange: function(component, event, helper) {
+		var value = component.get('v.value');
 
-        if ($A.util.isEmpty(value)) {
-            component.set('v.valueLabel', '');
-        } else if ($A.util.isEmpty(component.get('v.valueLabel'))) {
-            helper.getRecordByValue(component, event, helper);
-        }
-    },
+		if ($A.util.isEmpty(value)) {
+			component.set('v.valueLabel', '');
+		} else if ($A.util.isEmpty(component.get('v.valueLabel'))) {
+			helper.getRecordByValue(component, event, helper);
+		}
+	},
 
-    handleFilterChange: function(component, event, helper) {
-        component.set('v.initCallsRunning', 2);
+	handleFilterChange: function(component, event, helper) {
+		component.set('v.initCallsRunning', 2);
 
-        helper.getRecordByValue(component, event, helper);
-        helper.getRecentRecords(component, event, helper);
+		helper.getRecordByValue(component, event, helper);
+		helper.getRecentRecords(component, event, helper);
 
-        component.find('lookupInput').getElement().value = '';
-        helper.getRecordsBySearchTerm(component, event, helper);
-    },
-    handleLimitChange: function(component, event, helper) {
-        component.find('lookupInput').getElement().value = '';
-        helper.getRecordsBySearchTerm(component, event, helper);
-    },
-    handleObjectChange: function(component, event, helper) {
-        component.set('v.initCallsRunning', 3);
+		component.find('lookupInput').getElement().value = '';
+		helper.getRecordsBySearchTerm(component, event, helper);
+	},
+	handleLimitChange: function(component, event, helper) {
+		component.find('lookupInput').getElement().value = '';
+		helper.getRecordsBySearchTerm(component, event, helper);
+	},
+	handleObjectChange: function(component, event, helper) {
+		component.set('v.initCallsRunning', 3);
 
-        helper.getRecentRecords(component, event, helper);
-        helper.getRecordByValue(component, event, helper);
-        helper.getRecordLabel(component, event, helper);
+		helper.getRecentRecords(component, event, helper);
+		helper.getRecordByValue(component, event, helper);
+		helper.getRecordLabel(component, event, helper);
 
-        component.find('lookupInput').getElement().value = '';
-        helper.getRecordsBySearchTerm(component, event, helper);
-    },
-    handleOrderChange: function(component, event, helper) {
-        component.set('v.initCallsRunning', 1);
+		component.find('lookupInput').getElement().value = '';
+		helper.getRecordsBySearchTerm(component, event, helper);
+	},
+	handleOrderChange: function(component, event, helper) {
+		component.set('v.initCallsRunning', 1);
 
-        helper.getRecentRecords(component, event, helper);
+		helper.getRecentRecords(component, event, helper);
 
-        component.find('lookupInput').getElement().value = '';
-        helper.getRecordsBySearchTerm(component, event, helper);
-    },
-    handleSearchfieldChange: function(component, event, helper) {
-        component.set('v.initCallsRunning', 2);
+		component.find('lookupInput').getElement().value = '';
+		helper.getRecordsBySearchTerm(component, event, helper);
+	},
+	handleSearchfieldChange: function(component, event, helper) {
+		component.set('v.initCallsRunning', 2);
 
-        helper.getRecentRecords(component, event, helper);
-        helper.getRecordByValue(component, event, helper);
+		helper.getRecentRecords(component, event, helper);
+		helper.getRecordByValue(component, event, helper);
 
-        component.find('lookupInput').getElement().value = '';
-        helper.getRecordsBySearchTerm(component, event, helper);
-    },
-    handleSubtitlefieldChange: function(component, event, helper) {
-        component.set('v.initCallsRunning', 1);
+		component.find('lookupInput').getElement().value = '';
+		helper.getRecordsBySearchTerm(component, event, helper);
+	},
+	handleSubtitlefieldChange: function(component, event, helper) {
+		component.set('v.initCallsRunning', 1);
 
-        helper.getRecentRecords(component, event, helper);
+		helper.getRecentRecords(component, event, helper);
 
-        component.find('lookupInput').getElement().value = '';
-        helper.getRecordsBySearchTerm(component, event, helper);
-    },
+		component.find('lookupInput').getElement().value = '';
+		helper.getRecordsBySearchTerm(component, event, helper);
+	},
 
-    showError: function(component, event, helper) {
-        var errorMessage = event.getParam('arguments').errorMessage;
+	showError: function(component, event, helper) {
+		var errorMessage = event.getParam('arguments').errorMessage;
 
-        component.set('v.errorMessage', errorMessage);
-        component.set('v.error', true);
-    },
-    hideError: function(component, event, helper) {
-        component.set('v.errorMessage', null);
-        component.set('v.error', false);
-    }
+		component.set('v.errorMessage', errorMessage);
+		component.set('v.error', true);
+	},
+	hideError: function(component, event, helper) {
+		component.set('v.errorMessage', null);
+		component.set('v.error', false);
+	}
 })
 /*Copyright 2017 Appiphony, LLC
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
+	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+	following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following 
-disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following 
-disclaimer in the documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
-products derived from this software without specific prior written permission.
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following 
+	disclaimer.
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following 
+	disclaimer in the documentation and/or other materials provided with the distribution.
+	3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+	products derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+	SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+	WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/

--- a/aura/strike_lookup/strike_lookupHelper.js
+++ b/aura/strike_lookup/strike_lookupHelper.js
@@ -1,308 +1,312 @@
 /*Strike by Appiphony
 
-Version: 1.0.0
-Website: http://www.lightningstrike.io
-GitHub: https://github.com/appiphony/Strike-Components
-License: BSD 3-Clause License*/
+	Version: 1.0.0
+	Website: http://www.lightningstrike.io
+	GitHub: https://github.com/appiphony/Strike-Components
+	License: BSD 3-Clause License
+*/
 ({
-    checkIfInitialized: function(component, event, helper) {
-        var initCallsRunning = component.get('v.initCallsRunning');
+	checkIfInitialized: function(component, event, helper) {
+		var initCallsRunning = component.get('v.initCallsRunning');
 
-        if (--initCallsRunning < 0) {
-            initCallsRunning = 0;
-        }
+		if (--initCallsRunning < 0) {
+			initCallsRunning = 0;
+		}
 
-        component.set('v.initCallsRunning', initCallsRunning);
-    },
-    closeMenu: function(component, event, helper) {
-        component.set('v.focusIndex', null);
-        component.set('v.openMenu', false);
-    },
-    getParams: function(component, event, helper) {
-        var filter = component.get('v.filter');
-        var limit = component.get('v.limit');
-        var object = component.get('v.object');
-        var order = component.get('v.order');
-        var searchField = component.get('v.searchField');
-        var subtitleField = component.get('v.subtitleField');
+		component.set('v.initCallsRunning', initCallsRunning);
+	},
+	closeMenu: function(component, event, helper) {
+		component.set('v.focusIndex', null);
+		component.set('v.openMenu', false);
+	},
+	getParams: function(component, event, helper) {
+		var filter = component.get('v.filter');
+		var limit = component.get('v.limit');
+		var object = component.get('v.object');
+		var order = component.get('v.order');
+		var searchField = component.get('v.searchField');
+		var searchFields = component.get('v.searchFields');
+		var subtitleField = component.get('v.subtitleField');
 
-        return {
-            filter: filter,
-            limit: limit,
-            object: object,
-            order: order,
-            searchField: searchField,
-            subtitleField: subtitleField
-        };
-    },
-    getRecentRecords: function(component, event, helper) {
-        var returnedRecords = [];
+		return {
+			filter: filter,
+			limit: limit,
+			object: object,
+			order: order,
+			searchField: searchField,
+			searchFields: searchFields,
+			subtitleField: subtitleField
+		};
+	},
+	getRecentRecords: function(component, event, helper) {
+		var returnedRecords = [];
 
-        var getRecordsAction = component.get('c.getRecentRecords');
+		var getRecordsAction = component.get('c.getRecentRecords');
 
-        getRecordsAction.setParams({
-            jsonString: JSON.stringify(helper.getParams(component, event, helper))
-        });
+		getRecordsAction.setParams({
+			jsonString: JSON.stringify(helper.getParams(component, event, helper))
+		});
 
-        getRecordsAction.setCallback(this, function(res) {
-            if (res.getState() === 'SUCCESS') {
-                var returnValue = JSON.parse(res.getReturnValue());
+		getRecordsAction.setCallback(this, function(res) {
+			if (res.getState() === 'SUCCESS') {
+				var returnValue = JSON.parse(res.getReturnValue());
 
-                if (returnValue.isSuccess) {
-                    returnValue.results.data.forEach(function(record) {
-                        returnedRecords.push({
-                            label: record.label,
-                            sublabel: record.sublabel,
-                            value: record.value
-                        });
-                    });
-                }
-            }
-            component.set('v.recentRecords', returnedRecords);
+				if (returnValue.isSuccess) {
+					returnValue.results.data.forEach(function(record) {
+						returnedRecords.push({
+							label: record.label,
+							sublabel: record.sublabel,
+							value: record.value
+						});
+					});
+				}
+			}
+			component.set('v.recentRecords', returnedRecords);
 
-            helper.checkIfInitialized(component, event, helper);
-        });
+			helper.checkIfInitialized(component, event, helper);
+		});
 
-        $A.enqueueAction(getRecordsAction);
-    },
-    getRecordByValue: function(component, event, helper) {
-        var value = component.get('v.value');
+		$A.enqueueAction(getRecordsAction);
+	},
+	getRecordByValue: function(component, event, helper) {
+		var value = component.get('v.value');
 
-        if (!value) {
-            component.set('v.valueLabel', null);
-            component.set('v.valueSublabel', null);
-            helper.checkIfInitialized(component, event, helper);
+		if (!value) {
+			component.set('v.valueLabel', null);
+			component.set('v.valueSublabel', null);
+			helper.checkIfInitialized(component, event, helper);
 
-            return;
-        }
+			return;
+		}
 
-        var getRecordsAction = component.get('c.getRecords');
-        var params = helper.getParams(component, event, helper);
+		var getRecordsAction = component.get('c.getRecords');
+		var params = helper.getParams(component, event, helper);
 
-        if ($A.util.isEmpty(params.filter)) {
-            params.filter = 'Id = \'' + value + '\'';
-        } else {
-            params.filter = 'Id = \'' + value + '\' AND (' + params.filter + ')';
-        }
+		if ($A.util.isEmpty(params.filter)) {
+			params.filter = 'Id = \'' + value + '\'';
+		} else {
+			params.filter = 'Id = \'' + value + '\' AND (' + params.filter + ')';
+		}
 
-        getRecordsAction.setParams({
-            jsonString: JSON.stringify(params)
-        });
+		getRecordsAction.setParams({
+			jsonString: JSON.stringify(params)
+		});
 
-        getRecordsAction.setCallback(this, function(res) {
-            if (res.getState() === 'SUCCESS') {
-                var returnValue = JSON.parse(res.getReturnValue());
+		getRecordsAction.setCallback(this, function(res) {
+			if (res.getState() === 'SUCCESS') {
+				var returnValue = JSON.parse(res.getReturnValue());
 
-                if (returnValue.isSuccess) {
-                    returnValue.results.data.forEach(function(record) {
-                        component.set('v.valueLabel', record.label);
-                        component.set('v.valueSublabel', record.sublabel);
-                    });
-                }
-            }
+				if (returnValue.isSuccess) {
+					returnValue.results.data.forEach(function(record) {
+						component.set('v.valueLabel', record.label);
+						component.set('v.valueSublabel', record.sublabel);
+					});
+				}
+			}
 
-            helper.checkIfInitialized(component, event, helper);
-        });
+			helper.checkIfInitialized(component, event, helper);
+		});
 
-        $A.enqueueAction(getRecordsAction);
-    },
-    getRecordLabel: function(component, event, helper) {
-        var getRecordLabelAction = component.get('c.getRecordLabel');
+		$A.enqueueAction(getRecordsAction);
+	},
+	getRecordLabel: function(component, event, helper) {
+		var getRecordLabelAction = component.get('c.getRecordLabel');
 
-        getRecordLabelAction.setParams({
-            jsonString: JSON.stringify({
-                object: component.get('v.object')
-            })
-        });
+		getRecordLabelAction.setParams({
+			jsonString: JSON.stringify({
+				object: component.get('v.object')
+			})
+		});
 
-        getRecordLabelAction.setCallback(this, function(res) {
-            if (res.getState() === 'SUCCESS') {
-                var returnValue = JSON.parse(res.getReturnValue());
+		getRecordLabelAction.setCallback(this, function(res) {
+			if (res.getState() === 'SUCCESS') {
+				var returnValue = JSON.parse(res.getReturnValue());
 
-                if (returnValue.isSuccess) {
-                    component.set('v.objectLabel', returnValue.results.objectLabel);
-                }
-            }
+				if (returnValue.isSuccess) {
+					component.set('v.objectLabel', returnValue.results.objectLabel);
+				}
+			}
 
-            helper.checkIfInitialized(component, event, helper);
-        });
+			helper.checkIfInitialized(component, event, helper);
+		});
 
-        $A.enqueueAction(getRecordLabelAction);
-    },
-    getRecordsBySearchTerm: function(component, event, helper) {
-        var searchTerm = component.find('lookupInput').getElement().value;
+		$A.enqueueAction(getRecordLabelAction);
+	},
+	getRecordsBySearchTerm: function(component, event, helper) {
+		var searchTerm = component.find('lookupInput').getElement().value;
 
-        var lastSearchTerm = component.get('v.lastSearchTerm');
-        var searchTimeout = component.get('v.searchTimeout');
-        var showRecentRecords = component.get('v.showRecentRecords');
+		var lastSearchTerm = component.get('v.lastSearchTerm');
+		var searchTimeout = component.get('v.searchTimeout');
+		var showRecentRecords = component.get('v.showRecentRecords');
 
-        clearTimeout(searchTimeout);
+		clearTimeout(searchTimeout);
 
-        if ($A.util.isEmpty(searchTerm)) {
-            if (showRecentRecords) {
-                helper.setRecords(component, event, helper, component.get('v.recentRecords'));
-            } else {
-                helper.setRecords(component, event, helper, []);
-            }
+		if ($A.util.isEmpty(searchTerm)) {
+			if (showRecentRecords) {
+				helper.setRecords(component, event, helper, component.get('v.recentRecords'));
+			} else {
+				helper.setRecords(component, event, helper, []);
+			}
 
-            return;
-        } else if (searchTerm === lastSearchTerm) {
-            component.set('v.searching', false);
-            helper.openMenu(component, event, helper);
+			return;
+		} else if (searchTerm === lastSearchTerm) {
+			component.set('v.searching', false);
+			helper.openMenu(component, event, helper);
 
-            return;
-        }
-        
-        component.set('v.openMenu', true);
-        component.set('v.searching', true);
+			return;
+		}
+		
+		component.set('v.openMenu', true);
+		component.set('v.searching', true);
 
-        component.set('v.searchTimeout', setTimeout($A.getCallback(function() {
-            if (!component.isValid()) {
-                return;
-            }
+		component.set('v.searchTimeout', setTimeout($A.getCallback(function() {
+			if (!component.isValid()) {
+				return;
+			}
 
-            var getRecordsAction = component.get('c.getRecords');
-            var params = helper.getParams(component, event, helper);
+			var getRecordsAction = component.get('c.getRecords');
+			var params = helper.getParams(component, event, helper);
 
-            params.searchTerm = component.find('lookupInput').getElement().value;
+			params.searchTerm = component.find('lookupInput').getElement().value;
 
-            getRecordsAction.setParams({
-                jsonString: JSON.stringify(params)
-            });
+			getRecordsAction.setParams({
+				jsonString: JSON.stringify(params)
+			});
 
-            getRecordsAction.setCallback(this, function(res) {
-                if (res.getState() === 'SUCCESS') {
-                    var returnValue = JSON.parse(res.getReturnValue());
+			getRecordsAction.setCallback(this, function(res) {
+				if (res.getState() === 'SUCCESS') {
+					var returnValue = JSON.parse(res.getReturnValue());
 
-                    if (returnValue.isSuccess && returnValue.results.searchTerm === component.find('lookupInput').getElement().value) {
-                        var returnedRecords = [];
+					if (returnValue.isSuccess && returnValue.results.searchTerm === component.find('lookupInput').getElement().value) {
+						var returnedRecords = [];
 
-                        returnValue.results.data.forEach(function(record) {
-                            returnedRecords.push({
-                                label: record.label,
-                                sublabel: record.sublabel,
-                                value: record.value
-                            });
-                        });
+						returnValue.results.data.forEach(function(record) {
+							returnedRecords.push({
+								label: record.label,
+								sublabel: record.sublabel,
+								value: record.value
+							});
+						});
 
-                        helper.setRecords(component, event, helper, returnedRecords);
-                    }
-                } else {
-                    helper.setRecords(component, event, helper, []);
-                }
-            });
+						helper.setRecords(component, event, helper, returnedRecords);
+					}
+				} else {
+					helper.setRecords(component, event, helper, []);
+				}
+			});
 
-            $A.enqueueAction(getRecordsAction);
-        }), 200));
-    },
-    setRecords: function(component, event, helper, returnedRecords) {
-        component.set('v.focusIndex', null);
-        component.set('v.lastSearchTerm', component.find('lookupInput').getElement().value);
-        component.set('v.records', returnedRecords);
-        component.set('v.searching', false);
+			$A.enqueueAction(getRecordsAction);
+		}), 200));
+	},
+	setRecords: function(component, event, helper, returnedRecords) {
+		component.set('v.focusIndex', null);
+		component.set('v.lastSearchTerm', component.find('lookupInput').getElement().value);
+		component.set('v.records', returnedRecords);
+		component.set('v.searching', false);
 
-        helper.openMenu(component, event, helper);
-    },
-    openMenu: function(component, event, helper) {
-        var showRecentRecords = component.get('v.showRecentRecords') && !$A.util.isEmpty(component.get('v.recentRecords'));
-        component.set('v.openMenu', !component.get('v.disabled') && (!$A.util.isEmpty(component.get('v.lastSearchTerm')) || showRecentRecords));
-    },
-    closeMobileLookup: function(component, event, helper) {
-        $A.util.removeClass(component.find('lookup'), 'sl-lookup--open');
-        component.find('lookupInput').getElement().value = ''
-    },
-    updateValueByFocusIndex: function(component, event, helper) {
-        var focusIndex = component.get('v.focusIndex');
+		helper.openMenu(component, event, helper);
+	},
+	openMenu: function(component, event, helper) {
+		var showRecentRecords = component.get('v.showRecentRecords') && !$A.util.isEmpty(component.get('v.recentRecords'));
+		component.set('v.openMenu', !component.get('v.disabled') && (!$A.util.isEmpty(component.get('v.lastSearchTerm')) || showRecentRecords));
+	},
+	closeMobileLookup: function(component, event, helper) {
+		$A.util.removeClass(component.find('lookup'), 'sl-lookup--open');
+		component.find('lookupInput').getElement().value = ''
+	},
+	updateValueByFocusIndex: function(component, event, helper) {
+		var focusIndex = component.get('v.focusIndex');
 
-        if (focusIndex == null) {
-            focusIndex = 0;
-        }
+		if (focusIndex == null) {
+			focusIndex = 0;
+		}
 
-        var records = component.get('v.records');
+		var records = component.get('v.records');
 
-        if (focusIndex < records.length) {
-            component.set('v.value', records[focusIndex].value);
-            component.set('v.valueLabel', records[focusIndex].label);
-            component.set('v.valueSublabel', records[focusIndex].sublabel);
-            component.find('lookupInput').getElement().value = '';
+		if (focusIndex < records.length) {
+			component.set('v.value', records[focusIndex].value);
+			component.set('v.valueLabel', records[focusIndex].label);
+			component.set('v.valueSublabel', records[focusIndex].sublabel);
+			component.find('lookupInput').getElement().value = '';
 
-            helper.closeMenu(component, event, helper);
-        } else if (focusIndex === records.length) {
-            helper.addNewRecord(component, event, helper);
-        }
+			helper.closeMenu(component, event, helper);
+		} else if (focusIndex === records.length) {
+			helper.addNewRecord(component, event, helper);
+		}
 
-        helper.closeMobileLookup(component, event, helper);
-    },
-    addNewRecord: function(component, event, helper) {
-        if (!component.get('v.allowNewRecords')) {
-            return;
-        }
+		helper.closeMobileLookup(component, event, helper);
+	},
+	addNewRecord: function(component, event, helper) {
+		if (!component.get('v.allowNewRecords')) {
+			return;
+		}
 
-        var addRecordEvent;
-        var overrideNewEvent = component.get('v.overrideNewEvent');
+		var addRecordEvent;
+		var overrideNewEvent = component.get('v.overrideNewEvent');
 
-        if (overrideNewEvent) {
-            addRecordEvent = component.getEvent('strike_evt_addNewRecord');
-        } else {
-            addRecordEvent = $A.get('e.force:createRecord');
+		if (overrideNewEvent) {
+			addRecordEvent = component.getEvent('strike_evt_addNewRecord');
+		} else {
+			addRecordEvent = $A.get('e.force:createRecord');
 
-            addRecordEvent.setParams({
-                entityApiName: component.get('v.object')
-            });
-        }
-        addRecordEvent.fire();
+			addRecordEvent.setParams({
+				entityApiName: component.get('v.object')
+			});
+		}
+		addRecordEvent.fire();
 
-        helper.closeMenu(component, event, helper);
-    },
-    moveRecordFocusUp: function(component, event, helper) {
-        var openMenu = component.get('v.openMenu');
+		helper.closeMenu(component, event, helper);
+	},
+	moveRecordFocusUp: function(component, event, helper) {
+		var openMenu = component.get('v.openMenu');
 
-        if (openMenu) {
-            var focusIndex = component.get('v.focusIndex');
-            var options = component.find('lookupMenu').getElement().getElementsByTagName('li');
+		if (openMenu) {
+			var focusIndex = component.get('v.focusIndex');
+			var options = component.find('lookupMenu').getElement().getElementsByTagName('li');
 
-            if (focusIndex === null || focusIndex === 0) {
-                focusIndex = options.length - 1;
-            } else {
-                --focusIndex;
-            }
+			if (focusIndex === null || focusIndex === 0) {
+				focusIndex = options.length - 1;
+			} else {
+				--focusIndex;
+			}
 
-            component.set('v.focusIndex', focusIndex);
-        }
-    },
-    moveRecordFocusDown: function(component, event, helper) {
-        var openMenu = component.get('v.openMenu');
+			component.set('v.focusIndex', focusIndex);
+		}
+	},
+	moveRecordFocusDown: function(component, event, helper) {
+		var openMenu = component.get('v.openMenu');
 
-        if (openMenu) {
-            var focusIndex = component.get('v.focusIndex');
-            var options = component.find('lookupMenu').getElement().getElementsByTagName('li');
+		if (openMenu) {
+			var focusIndex = component.get('v.focusIndex');
+			var options = component.find('lookupMenu').getElement().getElementsByTagName('li');
 
-            if (focusIndex === null || focusIndex === options.length - 1) {
-                focusIndex = 0;
-            } else {
-                ++focusIndex;
-            }
+			if (focusIndex === null || focusIndex === options.length - 1) {
+				focusIndex = 0;
+			} else {
+				++focusIndex;
+			}
 
-            component.set('v.focusIndex', focusIndex);
-        }
-    }
+			component.set('v.focusIndex', focusIndex);
+		}
+	}
 })
 /*Copyright 2017 Appiphony, LLC
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
+	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+	following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following 
-disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following 
-disclaimer in the documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
-products derived from this software without specific prior written permission.
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following 
+	disclaimer.
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following 
+	disclaimer in the documentation and/or other materials provided with the distribution.
+	3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+	products derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+	SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+	WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/

--- a/classes/strike_lookupController.cls
+++ b/classes/strike_lookupController.cls
@@ -1,247 +1,279 @@
 /* --------------------------------------------------
-Strike by Appiphony
+	Strike by Appiphony
 
-Version: 0.10.0
-Website: http://www.lightningstrike.io
-GitHub: https://github.com/appiphony/Strike-Components
-License: BSD 3-Clause License
+	Version: 0.10.0
+	Website: http://www.lightningstrike.io
+	GitHub: https://github.com/appiphony/Strike-Components
+	License: BSD 3-Clause License
 -------------------------------------------------- */
 public with sharing class strike_lookupController {
-    @AuraEnabled
-    public static String getRecentRecords(String jsonString) {
-        strike_responseData responseData = new strike_responseData();
+	@AuraEnabled
+	public static String getRecentRecords(String jsonString) {
+		strike_responseData responseData = new strike_responseData();
 
-        try {
-            Map<String, Object> jsonMap = (Map<String, Object>)JSON.deserializeUntyped(jsonString);
-            Map<Id, RecentlyViewed> recentlyViewedMap = new Map<Id, RecentlyViewed>([SELECT Id
-                                                                                     FROM RecentlyViewed
-                                                                                     WHERE Type = :((String)jsonMap.get('object'))]);
-            List<Id> idList = new List<Id>(recentlyViewedMap.keySet());
+		try {
+			Map<String, Object> jsonMap = (Map<String, Object>)JSON.deserializeUntyped(jsonString);
+			Map<Id, RecentlyViewed> recentlyViewedMap = new Map<Id, RecentlyViewed>(
+				[SELECT Id FROM RecentlyViewed WHERE Type = :((String)jsonMap.get('object'))]);
+			List<Id> idList = new List<Id>(recentlyViewedMap.keySet());
 
-            if (idList.size() > 0) {
-                String filter = 'Id IN (\'' + String.join(idList, '\',\'') + '\')';
+			if (idList.size() > 0) {
+				String filter = 'Id IN (\'' + String.join(idList, '\',\'') + '\')';
 
-                if (strike_lookupController.fieldNotEmpty(jsonMap, 'filter')) {
-                    filter += ' AND (' + jsonMap.get('filter') + ')';
-                }
+				if (strike_lookupController.fieldNotEmpty(jsonMap, 'filter')) {
+					filter += ' AND (' + jsonMap.get('filter') + ')';
+				}
 
-                jsonMap.put('filter', filter);
+				jsonMap.put('filter', filter);
 
-                responseData.results = strike_lookupController.getData(jsonMap);
-            } else {
-                responseData.results = new Map<String, Object>{
-                    'data' => new List<String>(),
-                    'searchTerm' => ''
-                };
-            }
-        } catch (Exception e) {
-            responseData.addError(e.getMessage());
-        }
+				responseData.results = strike_lookupController.getData(jsonMap);
+			} else {
+				responseData.results = new Map<String, Object>{
+					'data' => new List<String>(),
+					'searchTerm' => ''
+				};
+			}
+		} catch (Exception e) {
+			responseData.addError(e.getMessage());
+		}
 
-        return responseData.getJsonString();
-    }
+		return responseData.getJsonString();
+	}
 
-    @AuraEnabled
-    public static String getRecordLabel(String jsonString) {
-        strike_responseData responseData = new strike_responseData();
+	@AuraEnabled
+	public static String getRecordLabel(String jsonString) {
+		strike_responseData responseData = new strike_responseData();
 
-        try {
-            Map<String, Object> jsonMap = (Map<String, Object>)JSON.deserializeUntyped(jsonString);
+		try {
+			Map<String, Object> jsonMap = (Map<String, Object>)JSON.deserializeUntyped(jsonString);
 
-            String obj = (String)jsonMap.get('object');
-            String objectLabel = Schema.describeSObjects(new List<String>{obj})[0].getLabel();
+			String obj = (String)jsonMap.get('object');
+			String objectLabel = Schema.describeSObjects(new List<String>{obj})[0].getLabel();
 
-            responseData.results.put('objectLabel', objectLabel);
-        } catch (Exception e) {
-            responseData.addError(e.getMessage());
-        }
+			responseData.results.put('objectLabel', objectLabel);
+		} catch (Exception e) {
+			responseData.addError(e.getMessage());
+		}
 
-        return responseData.getJsonString();
-    }
+		return responseData.getJsonString();
+	}
 
-    @AuraEnabled
-    public static String getRecords(String jsonString) {
-        strike_responseData responseData = new strike_responseData();
+	@AuraEnabled
+	public static String getRecords(String jsonString) {
+		strike_responseData responseData = new strike_responseData();
 
-        
-        try {
-            Map<String, Object> jsonMap = (Map<String, Object>)JSON.deserializeUntyped(jsonString);
-            responseData.results = strike_lookupController.getData(jsonMap);
-        } catch (Exception e) {
-            responseData.addError(e.getMessage());
-        }
+		try {
+			Map<String, Object> jsonMap = (Map<String, Object>)JSON.deserializeUntyped(jsonString);
+			responseData.results = strike_lookupController.getData(jsonMap);
+		} catch (Exception e) {
+			responseData.addError(e.getMessage());
+		}
 
-        return responseData.getJsonString();
-    }
+		return responseData.getJsonString();
+	}
 
-    private static Map<String, Object> getData(Map<String, Object> jsonMap) {
-        List<Map<String, Object>> data = new List<Map<String, Object>>();
+	private static Map<String, Object> getData(Map<String, Object> jsonMap) {
+		List<Map<String, Object>> data = new List<Map<String, Object>>();
 
-        String objType = String.escapeSingleQuotes((String)jsonMap.get('object'));
-        String query = strike_lookupController.getQuery(jsonMap);
-        String searchField = String.escapeSingleQuotes((String)jsonMap.get('searchField'));
-        String searchTerm = '';
-        String subtitleField;
+		String objType = String.escapeSingleQuotes((String)jsonMap.get('object'));
+		String query = strike_lookupController.getQuery(jsonMap);
+		String searchField = String.escapeSingleQuotes((String)jsonMap.get('searchField'));
+		String searchTerm = '';
+		String subtitleField;
 
-        if (strike_lookupController.fieldNotEmpty(jsonMap, 'subtitleField')) {
-            subtitleField = String.escapeSingleQuotes((String)jsonMap.get('subtitleField'));
-        }
+		if (strike_lookupController.fieldNotEmpty(jsonMap, 'subtitleField')) {
+			subtitleField = String.escapeSingleQuotes((String)jsonMap.get('subtitleField'));
+		}
 
-        if (strike_lookupController.fieldNotEmpty(jsonMap, 'searchTerm')) {
-            searchTerm = String.escapeSingleQuotes((String)jsonMap.get('searchTerm'));
-        }
+		if (strike_lookupController.fieldNotEmpty(jsonMap, 'searchTerm')) {
+			searchTerm = String.escapeSingleQuotes((String)jsonMap.get('searchTerm'));
+		}
 
-        if (String.isEmpty(subtitleField)) {
-            for (sObject obj : Database.query(query)) {
-                data.add(new Map<String, Object>{
-                    'label' => strike_lookupController.getValue(obj, objType, searchField),
-                    'value' => obj.get('Id')
-                });
-            }
-        } else {
-            for (sObject obj : Database.query(query)) {
-                data.add(new Map<String, Object>{
-                    'label' => strike_lookupController.getValue(obj, objType, searchField),
-                    'sublabel' => strike_lookupController.getValue(obj, objType, subtitleField),
-                    'value' => obj.get('Id')
-                });
-            }
-        }
+		if (String.isEmpty(subtitleField)) {
+			for (sObject obj : Database.query(query)) {
+				data.add(new Map<String, Object>{
+					'label' => strike_lookupController.getValue(obj, objType, searchField),
+					'value' => obj.get('Id')
+				});
+			}
+		} else {
+			for (sObject obj : Database.query(query)) {
+				data.add(new Map<String, Object>{
+					'label' => strike_lookupController.getValue(obj, objType, searchField),
+					'sublabel' => strike_lookupController.getValue(obj, objType, subtitleField),
+					'value' => obj.get('Id')
+				});
+			}
+		}
 
-        return new Map<String, Object>{
-                   'data' => data,
-                   'searchTerm' => searchTerm
-        };
-    }
+		return new Map<String, Object>{
+				'data' => data,
+				'searchTerm' => searchTerm
+		};
+	}
 
-    private static String getQuery(Map<String, Object> jsonMap) {
-        Set<String> queryFields = new Set<String>{'Id'};
-        List<String> filters = new List<String>();
-        List<String> orders = new List<String>();
+	private static String getQuery(Map<String, Object> jsonMap) {
+		Set<String> queryFields = new Set<String>{'Id'};
+		List<String> filters = new List<String>();
+		List<String> filtersORCondition = new List<String>();
+		List<String> orders = new List<String>();
 
-        String query;
-        String obj = String.escapeSingleQuotes((String)jsonMap.get('object'));
-        String subtitleField;
+		String query;
+		String obj = String.escapeSingleQuotes((String)jsonMap.get('object'));
+		String subtitleField;
 
-        if (strike_lookupController.fieldNotEmpty(jsonMap, 'subtitleField')) {
-            subtitleField = String.escapeSingleQuotes((String)jsonMap.get('subtitleField'));
-            queryFields.add(subtitleField);
-        }
+		if (strike_lookupController.fieldNotEmpty(jsonMap, 'subtitleField')) {
+			subtitleField = String.escapeSingleQuotes((String)jsonMap.get('subtitleField'));
+			queryFields.add(subtitleField);
+		}
 
-        if (strike_lookupController.fieldNotEmpty(jsonMap, 'searchField')) {
-            queryFields.add(String.escapeSingleQuotes((String)jsonMap.get('searchField')));
+		if (strike_lookupController.fieldNotEmpty(jsonMap, 'searchField')) {
+			queryFields.add(String.escapeSingleQuotes((String)jsonMap.get('searchField')));
 
-            if (strike_lookupController.fieldNotEmpty(jsonMap, 'searchTerm')) {
-                String searchField = String.escapeSingleQuotes((String)jsonMap.get('searchField'));
-                String searchTerm = String.escapeSingleQuotes((String)jsonMap.get('searchTerm'));
+			if (strike_lookupController.fieldNotEmpty(jsonMap, 'searchTerm')) {
+				String searchField = String.escapeSingleQuotes((String)jsonMap.get('searchField'));
+				String searchTerm = String.escapeSingleQuotes((String)jsonMap.get('searchTerm'));
 
-                filters.add(searchField + ' LIKE \'%' + searchTerm + '%\'');
-            }
-        }
+				if('Id'.equalsIgnoreCase(searchField)){
+					if(searchTerm instanceOf Id){
+						filtersORCondition.add(searchField + ' = \'' + searchTerm + '\'');
+					}
+				}else{
+					filters.add(searchField + ' LIKE \'%' + searchTerm + '%\'');
+				}
+			}
+		}
 
-        if (strike_lookupController.fieldNotEmpty(jsonMap, 'filter')) {
-            filters.add('(' + (String)jsonMap.get('filter') + ')');
-        }
+		if (strike_lookupController.fieldNotEmpty(jsonMap, 'searchFields')) {
+			Set<String> fieldstoAdd = new Set<String>( String.escapeSingleQuotes((String)jsonMap.get('searchFields')).split(',') );
+			queryFields.addAll(fieldstoAdd);
 
-        if (strike_lookupController.fieldNotEmpty(jsonMap, 'order')) {
-            orders.add(String.escapeSingleQuotes((String)jsonMap.get('order')));
-        }
+			if (strike_lookupController.fieldNotEmpty(jsonMap, 'searchTerm')) {
+				String searchFields = String.escapeSingleQuotes((String)jsonMap.get('searchFields'));
+				String searchTerm = String.escapeSingleQuotes((String)jsonMap.get('searchTerm'));
 
-        query = 'SELECT ' + String.join(new List<String>(queryFields), ', ');
-        query += ' FROM ' + obj;
+				List<String> searchConditions = new List<String>();
+				for(String searchField : searchFields.split(',')){
+					if('Id'.equalsIgnoreCase(searchField)){
+						searchConditions.add(searchField + ' = \'' + searchTerm + '\'');
+					}else{
+						searchConditions.add(searchField + ' LIKE \'%' + searchTerm + '%\'');
+					}
+				}
+				String searchCondition = '(' + String.join(searchConditions, ' OR ') + ')';
+				filters.add(searchCondition);
+			}
+		}
 
-        if (filters.size() > 0) {
-            query += ' WHERE ' + String.join(filters, ' AND ');
-        }
+		if (strike_lookupController.fieldNotEmpty(jsonMap, 'filter')) {
+			filters.add('(' + (String)jsonMap.get('filter') + ')');
+		}
 
-        if (orders.size() > 0) {
-            query += ' ORDER BY ' + String.join(orders, ', ');
-        }
+		if (strike_lookupController.fieldNotEmpty(jsonMap, 'order')) {
+			orders.add(String.escapeSingleQuotes((String)jsonMap.get('order')));
+		}
 
-        if (strike_lookupController.fieldNotEmpty(jsonMap, 'limit')) {
-            query += ' LIMIT ' + String.escapeSingleQuotes((String)jsonMap.get('limit'));
-        }
+		query = 'SELECT ' + String.join(new List<String>(queryFields), ', ');
+		query += ' FROM ' + obj;
 
-        return query;
-    }
+		if (filters.size() > 0) {
+			query += ' WHERE ' + String.join(filters, ' AND ');
+		}
 
-    private static Boolean fieldNotEmpty(Map<String, Object> jsonMap, String field) {
-        return jsonMap.containsKey(field) && !String.isEmpty((String)jsonMap.get(field));
-    }
+		if(filtersORCondition.size() > 0){
+			query += ' OR (' +String.join(filtersORCondition, ' OR ') + ')';
+		}
 
-    private static String getValue(SObject obj, String objectType, String field) {
-        List<String> fieldPath = field.split('[.]');
-        Object label = strike_utilities.convertObjectToMap(obj);
-        Map<String, Schema.SObjectField> fieldMap = Schema.getGlobalDescribe().get(objectType).getDescribe().fields.getMap();
+		if (orders.size() > 0) {
+			query += ' ORDER BY ' + String.join(orders, ', ');
+		}
 
-        for (String fieldName : fieldPath) {
-            fieldName = fieldName.replaceAll('__r$', '__c');
+		if (strike_lookupController.fieldNotEmpty(jsonMap, 'limit')) {
+			query += ' LIMIT ' + String.escapeSingleQuotes((String)jsonMap.get('limit'));
+		}
+		System.debug(LoggingLevel.FINEST, String.join(filters, ' AND '));
+		System.debug(LoggingLevel.FINEST, query);
+		return query;
+	}
 
-            label = ((Map<String, Object>)label).get(fieldName);
+	private static Boolean fieldNotEmpty(Map<String, Object> jsonMap, String field) {
+		return jsonMap.containsKey(field) && !String.isEmpty((String)jsonMap.get(field));
+	}
 
-            if (label == null) {
-                return '';
-            }
+	private static String getValue(SObject obj, String objectType, String field) {
+		List<String> fieldPath = field.split('[.]');
+		Object label = strike_utilities.convertObjectToMap(obj);
+		Map<String, Schema.SObjectField> fieldMap = Schema.getGlobalDescribe().get(objectType).getDescribe().fields.getMap();
 
-            if (fieldMap.containsKey(fieldName + 'Id')) {
-                fieldName = fieldName + 'Id';
-            }
+		for (String fieldName : fieldPath) {
+			fieldName = fieldName.replaceAll('__r$', '__c');
 
-            Schema.DescribeFieldResult fieldDescribe = fieldMap.get(fieldName).getDescribe();
-            String fieldType = String.valueOf(fieldDescribe.getType()).toUpperCase();
+			label = ((Map<String, Object>)label).get(fieldName);
 
-            if (fieldType == 'REFERENCE') {
-                fieldMap = Schema.getGlobalDescribe().get(String.valueOf(fieldDescribe.getReferenceTo().get(0))).getDescribe().fields.getMap();
-            } else if (fieldType == 'ADDRESS') {
-                List<String> addressComponents = new List<String>();
-                Map<String, Object> addr = (Map<String, Object>)label;
+			if (label == null) {
+				return '';
+			}
 
-                if (addr.containsKey('street') && addr.get('street') != null) {
-                    addressComponents.add((String)addr.get('street'));
-                }
+			if (fieldMap.containsKey(fieldName + 'Id')) {
+				fieldName = fieldName + 'Id';
+			}
 
-                if (addr.containsKey('city') && addr.get('city') != null) {
-                    addressComponents.add((String)addr.get('city'));
-                }
+			Schema.DescribeFieldResult fieldDescribe = fieldMap.get(fieldName).getDescribe();
+			String fieldType = String.valueOf(fieldDescribe.getType()).toUpperCase();
 
-                if (addr.containsKey('state') && addr.get('state') != null) {
-                    addressComponents.add((String)addr.get('state'));
-                }
+			if (fieldType == 'REFERENCE') {
+				fieldMap = Schema.getGlobalDescribe().get(String.valueOf(fieldDescribe.getReferenceTo().get(0))).getDescribe().fields.getMap();
+			} else if (fieldType == 'ADDRESS') {
+				List<String> addressComponents = new List<String>();
+				Map<String, Object> addr = (Map<String, Object>)label;
 
-                if (addr.containsKey('country') && addr.get('country') != null) {
-                    addressComponents.add((String)addr.get('country'));
-                }
+				if (addr.containsKey('street') && addr.get('street') != null) {
+					addressComponents.add((String)addr.get('street'));
+				}
 
-                if (addr.containsKey('postalCode') &&addr.get('postalCode') != null) {
-                    addressComponents.add((String)addr.get('postalCode'));
-                }
+				if (addr.containsKey('city') && addr.get('city') != null) {
+					addressComponents.add((String)addr.get('city'));
+				}
 
-                // change later for user formatting?
-                label = String.join(addressComponents, ', ');
-            }
-        }
+				if (addr.containsKey('state') && addr.get('state') != null) {
+					addressComponents.add((String)addr.get('state'));
+				}
 
-        return String.valueOf(label);
-    }
+				if (addr.containsKey('country') && addr.get('country') != null) {
+					addressComponents.add((String)addr.get('country'));
+				}
+
+				if (addr.containsKey('postalCode') &&addr.get('postalCode') != null) {
+					addressComponents.add((String)addr.get('postalCode'));
+				}
+
+				// change later for user formatting?
+				label = String.join(addressComponents, ', ');
+			}
+		}
+
+		return String.valueOf(label);
+	}
 }
 /* --------------------------------------------------
-Copyright 2017 Appiphony, LLC
+	Copyright 2017 Appiphony, LLC
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
-following conditions are met:
+	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+	following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following 
-disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following 
-disclaimer in the documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
-products derived from this software without specific prior written permission.
+	1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following 
+	disclaimer.
+	2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following 
+	disclaimer in the documentation and/or other materials provided with the distribution.
+	3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+	products derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
--------------------------------------------------- */
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+	SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+	SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+	WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------
+*/


### PR DESCRIPTION
Strike Lookup Enhancement - Allow Search by Id and by Multiple fields.

Current options only allow search by a single field in Strike Lookup and that doesn't include Id.

Have added seacrhFields property which accepts comma separated fieldnames against which searchTerm can be searched.